### PR TITLE
Add Solution for 2878. Get the Size of a DataFrame

### DIFF
--- a/pandas/Q2. Get the Size of a DataFrame/solution.md
+++ b/pandas/Q2. Get the Size of a DataFrame/solution.md
@@ -1,0 +1,40 @@
+# 2878. Get the Size of a DataFrame
+
+## Problem
+Given a pandas DataFrame `players` with information about players (columns like `player_id`, `name`, `age`, `position`, etc.), return the size of the DataFrame as an array `[number of rows, number of columns]`.
+
+---
+
+## Solution
+
+We can use the `.shape` attribute of a pandas DataFrame.  
+
+- `players.shape` returns a tuple `(number_of_rows, number_of_columns)`.  
+- We can unpack it and return it as a list.
+
+### Python Implementation
+ ```python  
+import pandas as pd
+from typing import List
+
+def getDataframeSize(players: pd.DataFrame) -> List[int]:
+    num_rows, num_cols = players.shape
+    return [num_rows, num_cols]
+```
+
+### Example Usage
+
+```python
+df = pd.DataFrame({
+    'player_id': [1, 2, 3],
+    'name': ['Alice', 'Bob', 'Charlie'],
+    'age': [25, 30, 22],
+    'position': ['Forward', 'Midfield', 'Defender']
+})
+```
+
+print(getDataframeSize(df))  # Output: [3, 4]
+
+
+
+


### PR DESCRIPTION
This PR adds a solution for problem 2878. Get the Size of a DataFrame. - Issue #77 
The solution demonstrates how to determine the size of a pandas DataFrame by returning [number_of_rows, number_of_columns]

<img width="1414" height="679" alt="Screenshot 2026-01-29 at 11 51 52 AM" src="https://github.com/user-attachments/assets/4abcfec5-9cb0-47f0-a9df-e9f5d3fa3e87" />

