### PR TITLE
Add solution for LeetCode 178 - Rank Scores

### DIFF
--- a/dbms/Q7. Rank Scores/solution.md
+++ b/dbms/Q7. Rank Scores/solution.md
@@ -1,0 +1,29 @@
+# LeetCode 178 — Rank Scores
+
+## Problem
+Table: `Scores`
+
+| Column Name | Type    |
+|------------|---------|
+| id         | int     |
+| score      | decimal |
+
+- `id` is the primary key.
+- Each row contains a game score.
+- Scores are floating-point values with two decimal places.
+
+### Ranking Rules
+- Rank scores from **highest to lowest**
+- Tied scores share the **same rank**
+- Rankings must be **consecutive** (no gaps)
+- Return results ordered by `score` descending
+
+## Solution (MySQL)
+
+```sql
+SELECT
+    score,
+    DENSE_RANK() OVER (ORDER BY score DESC) AS `rank`
+FROM Scores
+ORDER BY score DESC;
+```


### PR DESCRIPTION
### Title
Add MySQL solution for LeetCode 178-Rank Scores - Issue #57 

### Description
This PR adds a MySQL solution for LeetCode problem 178: Rank Scores.
The query ranks scores from highest to lowest, handles ties correctly, and ensures consecutive ranking without gaps.

<img width="1413" height="670" alt="Screenshot 2026-01-29 at 11 20 36 PM" src="https://github.com/user-attachments/assets/b1255960-ccda-45d1-84d4-2f735a6d83e6" />